### PR TITLE
Made the sidebar stick for the full length of the page, minus the footer

### DIFF
--- a/src/theme/DocPage/styles.module.css
+++ b/src/theme/DocPage/styles.module.css
@@ -14,6 +14,10 @@
   border-right: 1px solid var(--ifm-contents-border-color);
   box-sizing: border-box;
   width: 300px;
+  position: sticky;
+  position: -webkit-sticky;
+  max-height: 100vh;
+  top: 0;
 }
 
 .docMainContainer {

--- a/src/theme/DocSidebar/styles.module.css
+++ b/src/theme/DocSidebar/styles.module.css
@@ -10,8 +10,6 @@
     height: calc(100vh - var(--ifm-navbar-height));
     overflow-y: auto;
     padding: 0.5rem;
-    position: sticky;
-    top: var(--ifm-navbar-height);
   }
 
   .sidebar::-webkit-scrollbar {


### PR DESCRIPTION
This PR makes sure that the sidebar remains in view while scrolling (long) pages.