### PR TITLE
Added Setting up integration tests to the sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -69,6 +69,7 @@ module.exports = {
 				'standards/overview',
 				'standards/development-tools',
 				'standards/development-setup',
+				'standards/setting-up-integration-tests-for-the-plugins',
 				'standards/running-unit-tests-code-style-checks-and-linters',
 				'standards/coding-guidelines-and-principles',
 				'standards/version-control-conventions',


### PR DESCRIPTION
This PR adds a reference to the 'Setting up integration tests for the plugins' to the sidebar.

Requires https://github.com/Yoast/developer-docs/pull/7