### PR TITLE
Added meta tags to sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -45,6 +45,17 @@ module.exports = {
 
 				{
 					type: 'category',
+					label: 'Meta tags',
+					items: [
+						'features/meta-tags/overview',
+						'features/meta-tags/functional-specification',
+						'features/meta-tags/extensions-and-addons',
+						'features/meta-tags/api',
+					],
+				},
+
+				{
+					type: 'category',
 					label: 'Schema.org markup',
 					items: [
 						'features/schema/overview',


### PR DESCRIPTION
Adds the Meta tags section to the sidebar.

Requires: https://github.com/Yoast/developer-docs/pull/8