### PR TITLE
Added proper PHP syntax support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,6 +69,9 @@ module.exports = {
 			],
 			copyright: `Copyright © ${new Date().getFullYear()} Yoast · Built with Docusaurus.`,
 		},
+		prism: {
+			additionalLanguages: ['php'],
+		},
 	},
 	themes: ['@docusaurus/theme-search-algolia'],
 	presets: [


### PR DESCRIPTION
Somehow a change in the default theme for code blocks, removed PHP syntax highlighting.