### PR TITLE
Add the wp_get_environment_type() documentation to sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -157,6 +157,7 @@ module.exports = {
 						'customization/yoast-seo/disabling-yoast-seo',
 						'customization/yoast-seo/filters/capability-roles-filter',
 						'customization/yoast-seo/filtering-yoast-blocks',
+						'customization/yoast-seo/wp-get-environment-type-in-yoast-seo',
 					],
 				},
 				{


### PR DESCRIPTION
https://github.com/Yoast/developer-docs/pull/118 adds docs for `wp_get_environment_type()` function. This PR adds the documentation page to the site sidebar.