### PR TITLE
Added doc regarding new filter for Organization URL in Local SEO 13.9 to the sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -174,6 +174,7 @@ module.exports = {
 						'customization/local-seo/changing-location-url-google-maps',
 						'customization/local-seo/changing-location-post-type',
 						'customization/local-seo/enhancing-search-results',
+						'customization/local-seo/changing-organization-url-in-schema',
 					],
 				}
 			]


### PR DESCRIPTION

Yoast/developer-docs#120 adds documentation regarding new filter yoast-local-seo-schema-organization-url for Organization URL in Local SEO 13.9. This PR adds the documentation page to the site sidebar.