### PR TITLE
Add sidebar route for the subscription api documentation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -184,9 +184,9 @@ module.exports = {
 					items: [
 						{
 							type: 'category',
-							label: 'API\'s',
+							label: 'APIs',
 							items: [
-								'customization/myYoast/apis/subscription-api',
+								'customization/myyoast/apis/subscription-api',
 							],
 						}
 					],

--- a/sidebars.js
+++ b/sidebars.js
@@ -180,13 +180,13 @@ module.exports = {
 				},
 				{
 					type: 'category',
-					label: 'My-Yoast',
+					label: 'MyYoast',
 					items: [
 						{
 							type: 'category',
 							label: 'API\'s',
 							items: [
-								'customization/my-yoast/apis/subscription-api',
+								'customization/myYoast/apis/subscription-api',
 							],
 						}
 					],

--- a/sidebars.js
+++ b/sidebars.js
@@ -177,6 +177,19 @@ module.exports = {
 						'customization/local-seo/enhancing-search-results',
 						'customization/local-seo/changing-organization-url-in-schema',
 					],
+				},
+				{
+					type: 'category',
+					label: 'My-Yoast',
+					items: [
+						{
+							type: 'category',
+							label: 'API\'s',
+							items: [
+								'customization/my-yoast/apis/subscription-api',
+							],
+						}
+					],
 				}
 			]
 		},


### PR DESCRIPTION
Sibling-PR: https://github.com/Yoast/developer-docs/pull/127

We want to add documentation on the subscription API.

The issue requested it to be made available on the route:
Customization -> MyYoast -> API's -> Subscription API

This PR add the requested menu items.

dev-acceptance:

1. check out this PR and its sibling pr;
2. Check the menu items. Confirm that you can click customization > myYoast > Api's > subscription api. As described. and confirm the documentation on that page looks ok.