### PR TITLE
Add route for Shopify schema docs 

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -266,6 +266,7 @@ module.exports = {
 				'features/schema/plugins/woocommerce-seo',
 				'features/schema/plugins/news-seo',
 				'features/schema/plugins/video-seo',
+				'features/schema/plugins/yoast-seo-shopify',
 			]
 		},
 	],


### PR DESCRIPTION
Add route for Shopify schema docs.

Requires https://github.com/Yoast/developer-docs/pull/150.